### PR TITLE
Changing the job file

### DIFF
--- a/app/jobs/create_weekly_question_job.rb
+++ b/app/jobs/create_weekly_question_job.rb
@@ -1,4 +1,4 @@
-class Jobs::CreateWeeklyQuestion < ApplicationJob
+class CreateWeeklyQuestionJob < ApplicationJob
   queue_as :default
 
   def perform(*args)

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -1,4 +1,4 @@
 create_weekly_question:
   cron: "0 9 * * 1"
-  class: "Jobs::CreateWeeklyQuestion"
+  class: "CreateWeeklyQuestionJob"
   queue: default


### PR DESCRIPTION
Why:

* Deployment didn't work

This change addresses the need by:

* Changing the name of the Job file
* Removing the `Jobs` from the class name
