### PR TITLE
Sideqik worker

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -7,6 +7,11 @@ app = "center"
 primary_region = "mad"
 console_command = "/rails/bin/rails console"
 
+[processes]
+app = "bin/rails server"
+worker = "bundle exec sidekiq"
+
+
 [http_service]
   internal_port = 3000
   force_https = true


### PR DESCRIPTION
Why:

* Need to run background jobs on the deployment

This change addresses the need by:

* Setting up Redis and creating the `REDIS_URL` environment variable. Adding the processes to the `fly.toml` file