### PR TITLE
Only one answer per question per user

### DIFF
--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -2,4 +2,5 @@ class Answer < ApplicationRecord
   belongs_to :user
   belongs_to :question
   validates :body, presence: true
+  validates :user_id, uniqueness: {scope: :question_id}
 end

--- a/db/migrate/20230721162145_add_unique_answer.rb
+++ b/db/migrate/20230721162145_add_unique_answer.rb
@@ -1,0 +1,5 @@
+class AddUniqueAnswer < ActiveRecord::Migration[7.0]
+  def change
+    add_index :answers, [:user_id, :question_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_18_112930) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_21_162145) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -21,12 +21,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_18_112930) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["question_id"], name: "index_answers_on_question_id"
+    t.index ["user_id", "question_id"], name: "index_answers_on_user_id_and_question_id", unique: true
     t.index ["user_id"], name: "index_answers_on_user_id"
   end
 
   create_table "questions", force: :cascade do |t|
-    t.string "title"
-    t.text "content"
+    t.text "body"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end


### PR DESCRIPTION
Why:

* User can only have one answer per question.

This change addresses the need by:

* Creating the migration file to add an index on answers with question and user. Adding the validation on the answers model.