### PR TITLE
Fix NameError and returning nil

### DIFF
--- a/app/jobs/create_weekly_activities_job.rb
+++ b/app/jobs/create_weekly_activities_job.rb
@@ -1,6 +1,20 @@
 class CreateWeeklyActivitiesJob < ApplicationJob
   queue_as :default
 
+  def perform(*args)
+    unused_user = User.find_by(not_paired: true)
+
+    if unused_user
+      user_ids = User.where(not_paired: false).order("RANDOM()").pluck(:id).unshift(unused_user.id)
+      unused_user.update(not_paired: false)
+    else
+      user_ids = User.order("RANDOM()").pluck(:id)
+    end
+    pair(user_ids)
+  end
+
+  private
+
   def pair(user_ids)
     user_ids.each_slice(2) do |user_1, user_2|
       if user_2
@@ -9,17 +23,5 @@ class CreateWeeklyActivitiesJob < ApplicationJob
         User.find_by_id(user_1).update(not_paired: true)
       end
     end
-  end
-
-  def perform(*args)
-    unused_user = User.find_by(not_paired: true)
-
-    if unused_user.nil?
-      user_ids = User.order("RANDOM()").pluck(:id)
-    else
-      user_ids = User.where(not_paired: false).order("RANDOM()").pluck(:id).unshift(unused_user.id)
-      unused_user.update(not_paired: false)
-    end
-    pair(user_ids)
   end
 end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -5,5 +5,5 @@ create_weekly_question:
 
 create_weekly_activity:
   cron: "0 9 * * 1"
-  class: "CreateWeeklyActivityJob"
+  class: "CreateWeeklyActivitiesJob"
   queue: default


### PR DESCRIPTION
Why:

* We have a NameError running the weekly_activity cron job. 
* If there isn't any User with `not_paired` true the job would never run because of the `return unless unused_user` and we still want it to make the pairs.

This change addresses the need by:

* Changing the name on the `schedule.yml` file.
* Verifying if there's a `not_paired` user and if there's not we will still run the job.
