### PR TITLE
Using serializer for weekly_questions

### DIFF
--- a/app/controllers/weekly_questions_controller.rb
+++ b/app/controllers/weekly_questions_controller.rb
@@ -3,7 +3,12 @@ class WeeklyQuestionsController < ApplicationController
 
   # GET all the weekly questions with question body info
   def index
-    render json: WeeklyQuestion.all.to_json(include: {question: {only: :body}})
+    serialized = Alba.serialize(WeeklyQuestion.all) do
+      attributes :id, :week, :created_at, :updated_at
+
+      one :question
+    end
+    render json: serialized
   end
 
   # GET this weeks question

--- a/app/controllers/weekly_questions_controller.rb
+++ b/app/controllers/weekly_questions_controller.rb
@@ -3,11 +3,7 @@ class WeeklyQuestionsController < ApplicationController
 
   # GET all the weekly questions with question body info
   def index
-    serialized = Alba.serialize(WeeklyQuestion.all) do
-      attributes :id, :week, :created_at, :updated_at
-
-      one :question
-    end
+    serialized = WeeklyQuestionSerializer.new(WeeklyQuestion.all).serialize
     render json: serialized
   end
 

--- a/app/serializers/answer_serializer.rb
+++ b/app/serializers/answer_serializer.rb
@@ -1,0 +1,7 @@
+class AnswerSerializer
+  include Alba::Resource
+
+  attributes :id, :body, :created_at, :updated_at
+
+  one :user
+end

--- a/app/serializers/question_serializer.rb
+++ b/app/serializers/question_serializer.rb
@@ -1,0 +1,8 @@
+# The serialization result is the same as above
+class QuestionSerializer
+  include Alba::Resource
+
+  attributes :id, :body, :created_at, :updated_at
+
+  many :answers
+end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -2,5 +2,5 @@
 class UserSerializer
   include Alba::Resource
 
-  attributes :id, :name, :email, :password, :bio, :role, :profile_pic, :created_at, :updated_at
+  attributes :id, :name, :email, :profile_pic
 end

--- a/app/serializers/weekly_question_serializer.rb
+++ b/app/serializers/weekly_question_serializer.rb
@@ -1,0 +1,7 @@
+class WeeklyQuestionSerializer
+  include Alba::Resource
+
+  attributes :id, :week, :created_at, :updated_at
+
+  one :question
+end


### PR DESCRIPTION
Why:

* Facilitate the process on the FE without having to do multiple requests

This change addresses the need by:

* Creating the needed serializers in order that in one request we have all the information we need
