### PR TITLE
Fixing Fly time it runs the jobs

### DIFF
--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -1,9 +1,9 @@
 create_weekly_question:
-  cron: "0 9 * * 1"
+  cron: "0 8 * * 1"
   class: "CreateWeeklyQuestionJob"
   queue: default
 
 create_weekly_activity:
-  cron: "0 9 * * 1"
+  cron: "0 8 * * 1"
   class: "CreateWeeklyActivitiesJob"
   queue: default

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -1,9 +1,9 @@
 create_weekly_question:
-  cron: "0 8 * * 1"
+  cron: "0 9 * * 1 Europe/Lisbon"
   class: "CreateWeeklyQuestionJob"
   queue: default
 
 create_weekly_activity:
-  cron: "0 8 * * 1"
+  cron: "0 9 * * 1 Europe/Lisbon"
   class: "CreateWeeklyActivitiesJob"
   queue: default


### PR DESCRIPTION
Why:

* Fly has a different time and runs the jobs at our 10am.

This change addresses the need by:

* Changing the cron schedule.
