### PR TITLE
Give the time in which it was the weekly question

### DIFF
--- a/app/controllers/weekly_questions_controller.rb
+++ b/app/controllers/weekly_questions_controller.rb
@@ -3,7 +3,7 @@ class WeeklyQuestionsController < ApplicationController
 
   # GET all the weekly questions with question body info
   def index
-    serialized = WeeklyQuestionSerializer.new(WeeklyQuestion.all.offset(1)).serialize
+    serialized = WeeklyQuestionSerializer.new(WeeklyQuestion.where("week <= ?", Time.now)).serialize
     render json: serialized
   end
 

--- a/app/controllers/weekly_questions_controller.rb
+++ b/app/controllers/weekly_questions_controller.rb
@@ -3,13 +3,13 @@ class WeeklyQuestionsController < ApplicationController
 
   # GET all the weekly questions with question body info
   def index
-    serialized = WeeklyQuestionSerializer.new(WeeklyQuestion.all).serialize
+    serialized = WeeklyQuestionSerializer.new(WeeklyQuestion.all.offset(1)).serialize
     render json: serialized
   end
 
   # GET this weeks question
   def show
-    @week_question = WeeklyQuestion.find_by_week(Date.today.end_of_week + 1.day)
+    @week_question = WeeklyQuestion.find_by_week(Date.today.beginning_of_week)
     render json: @week_question, status: :ok
   end
 end

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -3,4 +3,5 @@ class Answer < ApplicationRecord
   belongs_to :question
   validates :body, presence: true
   validates :user_id, uniqueness: {scope: :question_id}
+  default_scope { order("created_at DESC") }
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,4 +1,5 @@
 class Question < ApplicationRecord
   validates :body, presence: true
   has_many :answers
+  default_scope { order("created_at DESC") }
 end

--- a/app/models/weekly_question.rb
+++ b/app/models/weekly_question.rb
@@ -1,4 +1,5 @@
 class WeeklyQuestion < ApplicationRecord
   belongs_to :question
   validates :week, presence: true, uniqueness: true
+  default_scope { order("created_at DESC") }
 end

--- a/app/serializers/weekly_question_serializer.rb
+++ b/app/serializers/weekly_question_serializer.rb
@@ -3,7 +3,7 @@ class WeeklyQuestionSerializer
 
   attributes :id, :week
 
-  attribute :during do |resource|
+  attribute :formatted_week do |resource|
     start_week = resource.week
     end_week = resource.week + 6
     "#{start_week.strftime("%d/%m")}-#{end_week.strftime("%d/%m")} "

--- a/app/serializers/weekly_question_serializer.rb
+++ b/app/serializers/weekly_question_serializer.rb
@@ -1,7 +1,13 @@
 class WeeklyQuestionSerializer
   include Alba::Resource
 
-  attributes :id, :week, :created_at, :updated_at
+  attributes :id, :week
+
+  attribute :during do |resource|
+    start_week = resource.week - 7
+    end_week = resource.week - 1
+    "#{start_week.strftime("%d/%m")}-#{end_week.strftime("%d/%m")} "
+  end
 
   one :question
 end

--- a/app/serializers/weekly_question_serializer.rb
+++ b/app/serializers/weekly_question_serializer.rb
@@ -4,8 +4,8 @@ class WeeklyQuestionSerializer
   attributes :id, :week
 
   attribute :during do |resource|
-    start_week = resource.week - 7
-    end_week = resource.week - 1
+    start_week = resource.week
+    end_week = resource.week + 6
     "#{start_week.strftime("%d/%m")}-#{end_week.strftime("%d/%m")} "
   end
 

--- a/spec/requests/week_question_controller_spec.rb
+++ b/spec/requests/week_question_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Weekly Question" do
       company = create(:company)
       user = create(:user, company_id: company.id)
       question = create(:question)
-      weekly_question = WeeklyQuestion.create(question: question, week: Date.today.end_of_week + 1.day)
+      weekly_question = WeeklyQuestion.create(question: question, week: Date.today.beginning_of_week)
       header = sign_in_as(user)
 
       get weekly_question_path, headers: header


### PR DESCRIPTION
Why:

* User needs to know during which time it was the weekly question on the previous questions page.

This change addresses the need by:

* Creating a new attribute on the serializer, this way giving the weekly question time it was "open". 
