### PR TITLE
Handle weekly_activities history.

### DIFF
--- a/app/controllers/weekly_friends_controller.rb
+++ b/app/controllers/weekly_friends_controller.rb
@@ -1,14 +1,16 @@
 class WeeklyFriendsController < ApplicationController
   def show
     user = User.find(params["id"])
-    weekly_activity = WeeklyActivity.active.includes_user(user.id)
+    active = WeeklyActivity.active
 
-    if weekly_activity.nil?
-      render json: user
-    elsif user.id == weekly_activity.pluck(:user_1_id)
-      render json: User.where(id: weekly_activity.pluck(:user_2_id))
+    if active.where(user_1_id: user.id).exists?
+      render json: active.find_by(user_1_id: user.id).user_2
+
+    elsif active.where(user_2_id: user.id).exists?
+      render json: active.find_by(user_2_id: user.id).user_1
+
     else
-      render json: User.where(id: weekly_activity.pluck(:user_1_id))
+      render json: user
     end
   end
 end

--- a/app/controllers/weekly_friends_controller.rb
+++ b/app/controllers/weekly_friends_controller.rb
@@ -5,10 +5,10 @@ class WeeklyFriendsController < ApplicationController
 
     if weekly_activity.nil?
       render json: user
-    elsif user == weekly_activity.user_1
-      render json: weekly_activity.user_2
+    elsif user.id == weekly_activity.pluck(:user_1_id)
+      render json: User.where(id: weekly_activity.pluck(:user_2_id))
     else
-      render json: weekly_activity.user_1
+      render json: User.where(id: weekly_activity.pluck(:user_1_id))
     end
   end
 end

--- a/app/controllers/weekly_friends_controller.rb
+++ b/app/controllers/weekly_friends_controller.rb
@@ -1,7 +1,8 @@
 class WeeklyFriendsController < ApplicationController
   def show
     user = User.find_by_id(params["id"])
-    weekly_activity = WeeklyActivity.where(user_1_id: user).or(WeeklyActivity.where(user_2_id: user)).first
+    active_activities = WeeklyActivity.where(active: true)
+    weekly_activity = active_activities.where(user_1_id: user).or(WeeklyActivity.where(user_2_id: user)).first
 
     if weekly_activity.nil?
       render json: user

--- a/app/controllers/weekly_friends_controller.rb
+++ b/app/controllers/weekly_friends_controller.rb
@@ -2,7 +2,7 @@ class WeeklyFriendsController < ApplicationController
   def show
     user = User.find_by_id(params["id"])
     active_activities = WeeklyActivity.where(active: true)
-    weekly_activity = active_activities.where(user_1_id: user).or(WeeklyActivity.where(user_2_id: user)).first
+    weekly_activity = active_activities.where(user_1_id: user).or(active_activities.where(user_2_id: user)).first
 
     if weekly_activity.nil?
       render json: user

--- a/app/controllers/weekly_friends_controller.rb
+++ b/app/controllers/weekly_friends_controller.rb
@@ -1,16 +1,16 @@
 class WeeklyFriendsController < ApplicationController
   def show
     user = User.find(params["id"])
-    active = WeeklyActivity.active
+    active_activities = WeeklyActivity.active
 
-    if active.where(user_1_id: user.id).exists?
-      render json: active.find_by(user_1_id: user.id).user_2
+    if active_activities.where(user_1: user).exists?
+      render json: active_activities.find_by(user_1: user).user_2
 
-    elsif active.where(user_2_id: user.id).exists?
-      render json: active.find_by(user_2_id: user.id).user_1
+    elsif active_activities.where(user_2: user).exists?
+      render json: active_activities.find_by(user_2: user).user_1
 
     else
-      render json: user
+      render json: {error: "not_found"}, status: 404
     end
   end
 end

--- a/app/controllers/weekly_friends_controller.rb
+++ b/app/controllers/weekly_friends_controller.rb
@@ -1,8 +1,7 @@
 class WeeklyFriendsController < ApplicationController
   def show
-    user = User.find_by_id(params["id"])
-    active_activities = WeeklyActivity.where(active: true)
-    weekly_activity = active_activities.where(user_1_id: user).or(active_activities.where(user_2_id: user)).first
+    user = User.find(params["id"])
+    weekly_activity = WeeklyActivity.active.includes_user(user.id)
 
     if weekly_activity.nil?
       render json: user

--- a/app/jobs/create_weekly_activities_job.rb
+++ b/app/jobs/create_weekly_activities_job.rb
@@ -2,7 +2,7 @@ class CreateWeeklyActivitiesJob < ApplicationJob
   queue_as :default
 
   def perform(*args)
-    WeeklyActivity.all.where(active: true).update_all(active: false)
+    WeeklyActivity.where(active: true).update_all(active: false)
     unused_user = User.find_by(not_paired: true)
 
     if unused_user

--- a/app/jobs/create_weekly_activities_job.rb
+++ b/app/jobs/create_weekly_activities_job.rb
@@ -2,6 +2,7 @@ class CreateWeeklyActivitiesJob < ApplicationJob
   queue_as :default
 
   def perform(*args)
+    WeeklyActivity.all.where(active: true).update_all(active: false)
     unused_user = User.find_by(not_paired: true)
 
     if unused_user

--- a/app/jobs/create_weekly_activities_job.rb
+++ b/app/jobs/create_weekly_activities_job.rb
@@ -2,7 +2,7 @@ class CreateWeeklyActivitiesJob < ApplicationJob
   queue_as :default
 
   def perform(*args)
-    WeeklyActivity.where(active: true).update_all(active: false)
+    WeeklyActivity.active.update_all(active: false)
     unused_user = User.find_by(not_paired: true)
 
     if unused_user

--- a/app/models/weekly_activity.rb
+++ b/app/models/weekly_activity.rb
@@ -3,6 +3,4 @@ class WeeklyActivity < ApplicationRecord
   belongs_to :user_2, class_name: "User"
 
   scope :active, -> { where(active: true) }
-
-  scope :includes_user, ->(user_id) { where(user_1_id: user_id).or(where(user_2_id: user_id)) }
 end

--- a/app/models/weekly_activity.rb
+++ b/app/models/weekly_activity.rb
@@ -1,4 +1,8 @@
 class WeeklyActivity < ApplicationRecord
   belongs_to :user_1, class_name: "User"
   belongs_to :user_2, class_name: "User"
+
+  scope :active, -> {where(active: true)}
+
+  scope :includes_user, -> (user_id) { where(user_1_id: user_id).or(where(user_2_id: user_id)) }
 end

--- a/app/models/weekly_activity.rb
+++ b/app/models/weekly_activity.rb
@@ -2,7 +2,7 @@ class WeeklyActivity < ApplicationRecord
   belongs_to :user_1, class_name: "User"
   belongs_to :user_2, class_name: "User"
 
-  scope :active, -> {where(active: true)}
+  scope :active, -> { where(active: true) }
 
-  scope :includes_user, -> (user_id) { where(user_1_id: user_id).or(where(user_2_id: user_id)) }
+  scope :includes_user, ->(user_id) { where(user_1_id: user_id).or(where(user_2_id: user_id)) }
 end

--- a/db/migrate/20230807111609_add_active_to_weekly_activity.rb
+++ b/db/migrate/20230807111609_add_active_to_weekly_activity.rb
@@ -1,0 +1,5 @@
+class AddActiveToWeeklyActivity < ActiveRecord::Migration[7.0]
+  def change
+    add_column :weekly_activities, :active, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_02_170650) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_07_111609) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -116,6 +116,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_02_170650) do
     t.bigint "user_2_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "active", default: true
     t.index ["user_1_id"], name: "index_weekly_activities_on_user_1_id"
     t.index ["user_2_id"], name: "index_weekly_activities_on_user_2_id"
   end


### PR DESCRIPTION
Why:

* We are selecting weekly friends from previous weeks because old activities stay in history. We need to choose only from weekly pairs of the current week.

This change addresses the need by:

* Add a column `active` to `weekly_activities` table to keep track of the updated pairs. This column should be true by default so the new created activities are automatically selected.
* Make the `weekly_friends_controller` choose only from active weekly_activities.
* Make the `create_weekly_activities_job` update the column `active` of all outdated weekly_activities to `false` so the controller ignore those. 