### PR TITLE
Company migration and run migrations

### DIFF
--- a/db/migrate/20230802170650_add_company_to_user.rb
+++ b/db/migrate/20230802170650_add_company_to_user.rb
@@ -2,7 +2,7 @@ class AddCompanyToUser < ActiveRecord::Migration[7.0]
   def change
     add_reference :users, :company, foreign_key: true
 
-    User.update_all(company_id: 1)
+    execute "UPDATE users SET company_id = 1;"
 
     change_column_null :users, :company_id, false
   end

--- a/db/migrate/20230802170650_add_company_to_user.rb
+++ b/db/migrate/20230802170650_add_company_to_user.rb
@@ -1,5 +1,9 @@
 class AddCompanyToUser < ActiveRecord::Migration[7.0]
   def change
-    add_reference :users, :company, null: false, foreign_key: true
+    add_reference :users, :company, foreign_key: true
+
+    User.update_all(company_id: 1)
+
+    change_column_null :users, :company_id, false
   end
 end

--- a/lib/tasks/fly.rake
+++ b/lib/tasks/fly.rake
@@ -1,0 +1,1 @@
+task release: "db:migrate"


### PR DESCRIPTION
Why:

* If we ran the migrations it would give an error because of null values on users

This change addresses the need by:
 
* Creating the column being null
* Updating all the registered users
* Creating a task that runs the migrations at release
