### PR TITLE
Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ FROM base as build
 
 # Install packages needed to build gems
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y build-essential libpq-dev
+    apt-get install --no-install-recommends -y build-essential libpq-dev libvips
 
 # Install application gems
 COPY --link Gemfile Gemfile.lock ./
@@ -44,7 +44,7 @@ FROM base
 
 # Install packages needed for deployment
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y curl postgresql-client && \
+    apt-get install --no-install-recommends -y curl imagemagick libvips postgresql-client && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Copy built artifacts: gems, application
@@ -65,4 +65,3 @@ ENTRYPOINT ["/rails/bin/docker-entrypoint"]
 
 # Start the server by default, this can be overwritten at runtime
 EXPOSE 3000
-CMD ["./bin/rails", "server"]

--- a/fly.toml
+++ b/fly.toml
@@ -8,8 +8,8 @@ primary_region = "mad"
 console_command = "/rails/bin/rails console"
 
 [processes]
-app = "bin/rails server"
-worker = "bundle exec sidekiq"
+  app = "./bin/rails server"
+  sidekiq = "bundle exec sidekiq"
 
 
 [http_service]


### PR DESCRIPTION
Why:

* Migrations not running by itself.

This change addresses the need by:

* Running the command `bin/rails generate dockerfile`
