### PR TITLE
Default pic to existing users

### DIFF
--- a/db/migrate/20230817162236_add_default_pic_to_existing_users.rb
+++ b/db/migrate/20230817162236_add_default_pic_to_existing_users.rb
@@ -1,6 +1,8 @@
 class AddDefaultPicToExistingUsers < ActiveRecord::Migration[7.0]
   def change
-    User.where(profile_pic: nil).each do |user|
+    User.find_each do |user|
+      next if user.profile_pic.attached?
+
       user.profile_pic.attach(io: File.open("#{Rails.root}/app/assets/images/profile.png"), filename: "profile.png", content_type: "image/png")
     end
   end

--- a/db/migrate/20230817162236_add_default_pic_to_existing_users.rb
+++ b/db/migrate/20230817162236_add_default_pic_to_existing_users.rb
@@ -1,0 +1,7 @@
+class AddDefaultPicToExistingUsers < ActiveRecord::Migration[7.0]
+  def change
+    User.where(profile_pic: nil).each do |user|
+      user.profile_pic.attach(io: File.open("#{Rails.root}/app/assets/images/profile.png"), filename: "profile.png", content_type: "image/png")
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_11_171617) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_17_162236) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 


### PR DESCRIPTION
Why:

* Display pictures when user doesn't have one.

This change addresses the need by:

* Creating a migration that adds a default picture to the existing users.
